### PR TITLE
Fix random word selection bug

### DIFF
--- a/js/wordleJS.js
+++ b/js/wordleJS.js
@@ -143,9 +143,9 @@ let wordle;
 let wordleArr;
 
 function pickWordle() {
-  const valuesLengthRNG = newRNG(0, values.length);
+  const valuesLengthRNG = newRNG(0, values.length - 1);
   const valuesWordsArr = values[valuesLengthRNG];
-  const valuesArrayLengthRNG = newRNG(0, valuesWordsArr.length);
+  const valuesArrayLengthRNG = newRNG(0, valuesWordsArr.length - 1);
   wordle = valuesWordsArr[valuesArrayLengthRNG];
   wordleArr = wordle.split('');
 


### PR DESCRIPTION
## Summary
- fix random index bounds when selecting a word

## Testing
- `node -e "function newRNG(min,max){return Math.floor(Math.random()*(max-min+1)+min);} let values=Array(26).fill(null); let outOfRange=false; for(let i=0;i<1e5;i++){ let idx=newRNG(0, values.length-1); if(idx>=values.length) outOfRange=true;} console.log(outOfRange);"

------
https://chatgpt.com/codex/tasks/task_e_6851be4e2e9883339ec724be52f45cf9