### PR TITLE
Add end game modal

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -474,6 +474,31 @@ o | replace active with add+remove becuase animation shuld be activated on tap, 
   margin-bottom: 2rem;
 }
 
+/* End game modal */
+.end-modal {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 10;
+  width: 100%;
+  height: 100%;
+
+  background-color: #0000005e;
+}
+.end-modal .modal-content {
+  background-color: var(--light-black);
+  color: var(--white);
+  border-radius: 1rem;
+
+  line-height: 1.2;
+  padding: 3rem 3rem 3rem 3rem;
+  font-size: 1.3rem;
+  text-align: center;
+}
+
 .example:nth-of-type(1) letter {
   color: var(--green);
 }
@@ -616,6 +641,9 @@ o | replace active with add+remove becuase animation shuld be activated on tap, 
   }
 
   .modal {
+    height: var(--doc-height);
+  }
+  .end-modal {
     height: var(--doc-height);
   }
   .modal-content {

--- a/index.html
+++ b/index.html
@@ -178,6 +178,16 @@ SHARAPA
         </div>
       </div>
 
+      <div class="end-modal hidden">
+        <div class="modal-content">
+          <h1 class="end-title"></h1>
+          <p>The correct word was: <span class="end-word"></span></p>
+          <div class="button-container">
+            <button class="closeEndModalButton">OK</button>
+          </div>
+        </div>
+      </div>
+
     </main>
   </body>
 </html>

--- a/js/wordleJS.js
+++ b/js/wordleJS.js
@@ -205,6 +205,10 @@ const header = document.querySelector('.header');
 const modal = document.querySelector('.modal');
 
 const closeModalButton = document.querySelector('.closeModalButton');
+const endModal = document.querySelector('.end-modal');
+const endTitle = document.querySelector('.end-title');
+const endWord = document.querySelector('.end-word');
+const closeEndModalButton = document.querySelector('.closeEndModalButton');
 
 // o | need to add X to close the modal window
 
@@ -266,6 +270,17 @@ function startupAnimations() {
   }
 }
 startupAnimations();
+
+function showEndModal(win) {
+  endTitle.textContent = win ? 'You won!' : 'You lost!';
+  endWord.textContent = wordle.toUpperCase();
+  endModal.classList.remove('hidden');
+}
+
+closeEndModalButton.addEventListener('click', () => {
+  endModal.classList.add('hidden');
+  location.reload();
+});
 //> -----------------------------------------------------------------
 // document.addEventListener('click', function (e) {
 //   console.log(e);
@@ -382,8 +397,7 @@ function gameKeydown(e) {
                 .querySelector(`.k--${g}`)
                 .classList.remove('char--yellow');
               document.querySelector(`.k--${g}`).classList.add('char--green');
-            } //-
-            else if (wordleArrFiltered.includes(g)) {
+            } else if (wordleArrFiltered.includes(g)) {
               //. input fields
               charArr[wIndex].classList.add('char--yellow');
               wordleArrFiltered.splice(wordleArrFiltered.indexOf(g), 1);
@@ -399,11 +413,17 @@ function gameKeydown(e) {
               document.querySelector(`.k--${g}`).classList.add('char--none');
             }
           }, wIndex * 500);
-          if (wordle === guess)
-            setTimeout(() => {
-              logo.forEach(l => l.classList.add('char--green'));
-            }, 2500);
         });
+
+        if (wordle === guess)
+          setTimeout(() => {
+            logo.forEach(l => l.classList.add('char--green'));
+            showEndModal(true);
+          }, 2500);
+        else if (currentRow === rowsAllArr.length)
+          setTimeout(() => {
+            showEndModal(false);
+          }, 2500);
 
         // & <==========< end of game logic >==========>
 
@@ -461,6 +481,10 @@ function click(e) {
 
   // - remove modal window
   e.target === closeModalButton && modal.classList.add('hidden');
+  if (e.target === closeEndModalButton) {
+    endModal.classList.add('hidden');
+    location.reload();
+  }
 }
 //
 


### PR DESCRIPTION
## Summary
- add new end game modal HTML structure
- style end game modal
- implement logic to display end modal on win or loss

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851e432dfbc83338d5f16daf6cd8c56