### PR TITLE
Disable mobile zoom

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -292,6 +292,9 @@ button:hover {
   width: var(--keyboard-width);
   margin-top: 14rem;
 
+  /* prevent double-tap zoom */
+  touch-action: manipulation;
+
   /* prevent selection */
   -webkit-user-select: none; /* Safari */
   -ms-user-select: none; /* IE 10 and IE 11 */
@@ -329,6 +332,9 @@ button:hover {
   display: flex;
   justify-content: center;
   align-items: center;
+
+  /* prevent double-tap zoom when pressing keys */
+  touch-action: manipulation;
 
   flex: 1 1; /* grow + shrink > 0% */
 }

--- a/index.html
+++ b/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+    />
     <title>Wordle and other projects</title>
 
     <!-- * Fonts -->


### PR DESCRIPTION
## Summary
- prevent zooming on mobile by adding `user-scalable=no` and `maximum-scale=1`
- ensure the on-screen keyboard doesn't trigger double‑tap zoom

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868fe3f81a883338da49ea15d12dd41