### PR TITLE
Fix duplicate end-modal reload

### DIFF
--- a/js/wordleJS.js
+++ b/js/wordleJS.js
@@ -277,10 +277,6 @@ function showEndModal(win) {
   endModal.classList.remove('hidden');
 }
 
-closeEndModalButton.addEventListener('click', () => {
-  endModal.classList.add('hidden');
-  location.reload();
-});
 //> -----------------------------------------------------------------
 // document.addEventListener('click', function (e) {
 //   console.log(e);


### PR DESCRIPTION
## Summary
- remove redundant click handler on end modal

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688696f2264c83339d2bbafcf5cd9805