### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/css/responsive.css
+++ b/css/responsive.css
@@ -1,0 +1,51 @@
+:root {
+  --tile-size: clamp(3rem, 12vw, 6rem);
+  --key-size: clamp(2.4rem, 10vw, 5rem);
+}
+
+.row {
+  display: grid;
+  grid-template-columns: repeat(5, var(--tile-size));
+  justify-content: center;
+  gap: 0.4rem;
+}
+
+.char {
+  width: var(--tile-size);
+  height: var(--tile-size);
+  font-size: calc(var(--tile-size) * 0.6);
+}
+
+.keyboard {
+  width: min(96vw, 40rem);
+  margin: 2rem auto 0;
+}
+
+.kb-row {
+  display: flex;
+  justify-content: center;
+  gap: 0.3rem;
+}
+
+.key {
+  width: var(--key-size);
+  height: var(--key-size);
+  font-size: calc(var(--key-size) * 0.6);
+}
+
+.k--Enter,
+.k--Backspace {
+  flex: 1.5 1.5;
+}
+
+@media (max-width: 34em) {
+  :root {
+    --tile-size: 12vw;
+    --key-size: 10vw;
+  }
+
+  .keyboard {
+    width: 96vw;
+    margin-top: 0;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
 <!--  -->
     <link rel="stylesheet" href="css/webfontkit/stylesheet.css">
     <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="css/responsive.css">
     <link rel="stylesheet" href="css/keyframes.css">
     <script defer src="js/wordle-words-list.js"></script>
     <script defer src="js/wordleJS.js"></script>


### PR DESCRIPTION
## Summary
- add new `responsive.css` with clamp-based sizing for tiles and keys
- load the new stylesheet in `index.html`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886ac6c3dc48333978f33c1e9be992b