### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/css/responsive.css
+++ b/css/responsive.css
@@ -1,0 +1,51 @@
+:root {
+  --tile-size: clamp(3rem, 12vw, 6rem);
+  --key-size: clamp(2.4rem, 10vw, 5rem);
+}
+
+.row {
+  display: grid;
+  grid-template-columns: repeat(5, var(--tile-size));
+  justify-content: center;
+  gap: 0.4rem;
+}
+
+.char {
+  width: var(--tile-size);
+  height: var(--tile-size);
+  font-size: calc(var(--tile-size) * 0.6);
+}
+
+.keyboard {
+  width: min(96vw, 40rem);
+  margin: 2rem auto 0;
+}
+
+.kb-row {
+  display: flex;
+  justify-content: center;
+  gap: 0.3rem;
+}
+
+.key {
+  width: var(--key-size);
+  height: var(--key-size);
+  font-size: calc(var(--key-size) * 0.6);
+}
+
+.k--Enter,
+.k--Backspace {
+  flex: 1.5 1.5;
+}
+
+@media (max-width: 34em) {
+  :root {
+    --tile-size: 12vw;
+    --key-size: 10vw;
+  }
+
+  .keyboard {
+    width: 96vw;
+    margin-top: 0;
+  }
+}

--- a/css/style.css
+++ b/css/style.css
@@ -504,6 +504,12 @@ o | replace active with add+remove becuase animation shuld be activated on tap, 
   text-align: center;
 }
 
+.end-modal .end-title {
+  color: coral;
+  font-size: 4rem;
+  margin-bottom: 2rem;
+}
+
 .example:nth-of-type(1) letter {
   color: var(--green);
 }

--- a/index.html
+++ b/index.html
@@ -31,9 +31,11 @@
 <!--  -->
     <link rel="stylesheet" href="css/webfontkit/stylesheet.css">
     <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="css/responsive.css">
     <link rel="stylesheet" href="css/keyframes.css">
     <script defer src="js/wordle-words-list.js"></script>
     <script defer src="js/wordleJS.js"></script>
+    <script defer src="js/no-double-tap.js"></script>
   </head>
 
   <body>
@@ -41,7 +43,7 @@
       <div class="sharapaio">
 SHARAPA
       </div>
-      <div class="version">BETA 0.7.7</div>
+      <div class="version">BETA 0.7.8</div>
     </header>
     <main>
 

--- a/js/no-double-tap.js
+++ b/js/no-double-tap.js
@@ -1,0 +1,28 @@
+(function() {
+  let lastTouchEnd = 0;
+
+  // prevent pinch zoom
+  document.addEventListener(
+    'touchstart',
+    function(e) {
+      if (e.touches.length > 1) {
+        e.preventDefault();
+      }
+    },
+    { passive: false }
+  );
+
+  // prevent double-tap zoom while still letting the tap fire
+  document.addEventListener(
+    'touchend',
+    function(e) {
+      const now = Date.now();
+      if (now - lastTouchEnd <= 300) {
+        e.preventDefault();
+        e.target.dispatchEvent(new Event('click', { bubbles: true }));
+      }
+      lastTouchEnd = now;
+    },
+    { passive: false }
+  );
+})();

--- a/js/wordleJS.js
+++ b/js/wordleJS.js
@@ -156,7 +156,34 @@ function pickWordle() {
     `this is the word you need to guess: [ ${wordle.toUpperCase()} ]`
   );
 }
-pickWordle();
+
+function initGame() {
+  pickWordle();
+
+  guess = '';
+  guessArr = [];
+  count = -1;
+  currentRow = 0;
+
+  rowsAllArr.forEach(r => {
+    r.classList.remove('row--false');
+    Array.from(r.children).forEach(c => {
+      c.value = '';
+      c.classList.remove(
+        'char--transition',
+        'char--rotate',
+        'char--green',
+        'char--yellow'
+      );
+    });
+  });
+
+  document.querySelectorAll('.key').forEach(k => {
+    k.classList.remove('char--green', 'char--yellow', 'char--none');
+  });
+
+  logo.forEach(l => l.classList.remove('char--green'));
+}
 
 //* Matching word in the database
 const guessTest = 'hants';
@@ -212,6 +239,10 @@ const closeEndModalButton = document.querySelector('.closeEndModalButton');
 
 // o | need to add X to close the modal window
 
+let logoContainer;
+let logoLetters;
+let overlay;
+
 function addLogoScreen() {
   header.insertAdjacentHTML(
     'afterbegin',
@@ -227,18 +258,17 @@ function addLogoScreen() {
         <div class='overlay'></div>
 `
   );
+  logoContainer = document.querySelector('.logo-container');
+  logoLetters = [...document.querySelectorAll('.logo')];
+  overlay = document.querySelector('.overlay');
 }
+
 addLogoScreen();
 
-const logoContainer = document.querySelector('.logo-container');
-const logoLetters = [...document.querySelectorAll('.logo')];
-const overlay = document.querySelector('.overlay');
-
 function startupAnimations() {
-  document.addEventListener('DOMContentLoaded', runAnimation);
   function runAnimation() {
     logoContainer.classList.remove('move-in-out');
-    this.offsetWidth; //> returns read-only property of layout-width of element
+    logoContainer.offsetWidth; // force reflow
     logoContainer.classList.add('move-in-out');
 
     logoLetters.reverse().forEach((l, i) => {
@@ -259,13 +289,19 @@ function startupAnimations() {
     }, 2000);
   }
 
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', runAnimation);
+  } else {
+    runAnimation();
+  }
+
   logoContainer.addEventListener('animationend', removeLogoScreen);
   function removeLogoScreen() {
     setTimeout(() => {
       logoContainer.remove();
       overlay.remove();
       modal.classList.remove('hidden');
-      // ! only after animation end initiate the game function
+      initGame();
     }, 2000);
   }
 }
@@ -479,7 +515,8 @@ function click(e) {
   e.target === closeModalButton && modal.classList.add('hidden');
   if (e.target === closeEndModalButton) {
     endModal.classList.add('hidden');
-    location.reload();
+    addLogoScreen();
+    startupAnimations();
   }
 }
 //


### PR DESCRIPTION
## Summary
- add new `responsive.css` with clamp-based sizing for tiles and keys
- load the new stylesheet in `index.html`
- prevent double-tap zoom on mobile
- reset board and restart game without a full page reload
- fix double-tap handling so buttons still register
- style win/lose modal like rules modal
- **bump app version to 0.7.8**

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6886ac6c3dc48333978f33c1e9be992b