### PR TITLE
Add localStorage persistence

### DIFF
--- a/css/tailwind-overrides.css
+++ b/css/tailwind-overrides.css
@@ -35,3 +35,73 @@
 .end-word-link {
   text-decoration: none;
 }
+
+/* Smaller text for rule explanations */
+.rules-desc {
+  font-size: 1rem;
+}
+
+/* Startup logo animation styles */
+.logo-container {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  gap: 0.5rem;
+  z-index: 50;
+}
+
+.logo-container .logo {
+  width: 3.5rem;
+  height: 3.5rem;
+  font-size: 2.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid #000;
+  border-radius: 0.25rem;
+  background-color: #444;
+  color: #fff;
+}
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.4);
+  z-index: 40;
+}
+
+/* Example word layout */
+.example {
+  display: flex;
+  gap: 0.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.char-example {
+  width: 3.5rem;
+  height: 3.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid #000;
+  border-radius: 0.25rem;
+  background-color: #444;
+  color: #fff;
+}
+
+.char-example.char--green {
+  background-color: #8dff94;
+  color: #444;
+}
+
+.char-example.char--yellow {
+  background-color: #f4ff61;
+  color: #444;
+}
+
+.char-example.char--none {
+  background-color: #6a6a6a;
+  color: #fff;
+}

--- a/index.html
+++ b/index.html
@@ -137,13 +137,13 @@ SHARAPA
       <div class="modal hidden fixed inset-0 flex items-center justify-center bg-black/40">
         <div class="modal-content bg-light-black text-white rounded p-8 text-[1.3rem]">
           <h1>How to play</h1>
-          <p>Guess the WORDLE in 6 tries.</p>
-          <p>Each guess must be a valid 5-letter word. Hit the enter button to submit.</p>
-          <p>After each guess, the color of the tiles will change to show how close your guess was to the word.</p>
+          <p class="rules-desc">Guess the WORDLE in six tries.</p>
+          <p class="rules-desc">Each guess must be a valid five-letter word. Hit Enter to submit.</p>
+          <p class="rules-desc">After each guess, the tile colors show how close you were.</p>
           <hr>
           <p><strong>Examples</strong></p>
           <div class="example">
-            <div class="char-example green">W</div>
+            <div class="char-example char--green">W</div>
             <div class="char-example">E</div>
             <div class="char-example">A</div>
             <div class="char-example">R</div>
@@ -152,7 +152,7 @@ SHARAPA
           <p><strong>The Letter W is in the word and in the correct spot</strong></p>
           <div class="example">
             <div class="char-example">P</div>
-            <div class="char-example yellow">I</div>
+            <div class="char-example char--yellow">I</div>
             <div class="char-example">L</div>
             <div class="char-example">L</div>
             <div class="char-example">S</div>
@@ -162,12 +162,12 @@ SHARAPA
             <div class="char-example">V</div>
             <div class="char-example">A</div>
             <div class="char-example">G</div>
-            <div class="char-example none">U</div>
+            <div class="char-example char--none">U</div>
             <div class="char-example">E</div>
           </div>
           <p><strong>The letter U is not in the word in any spot.</strong></p>
           <hr>
-          <p>A new WORDLE will be available each time you start a new game!</p>
+          <p class="rules-desc">New WORDLE each time you start a game!</p>
           <div class="button-container flex justify-center mt-8">
             <button class="closeModalButton bg-[coral] text-black px-4 py-2 rounded font-bold text-3xl">PLAY</button>
           </div>

--- a/js/wordleJS.js
+++ b/js/wordleJS.js
@@ -183,6 +183,7 @@ function initGame() {
   });
 
   logo.forEach(l => l.classList.remove('char--green'));
+  saveGameState();
 }
 
 //* Matching word in the database
@@ -264,8 +265,6 @@ function addLogoScreen() {
   overlay = document.querySelector('.overlay');
 }
 
-addLogoScreen();
-
 function startupAnimations() {
   function runAnimation() {
     logoContainer.classList.remove('move-in-out');
@@ -301,12 +300,16 @@ function startupAnimations() {
     setTimeout(() => {
       logoContainer.remove();
       overlay.remove();
-      modal.classList.remove('hidden');
-      initGame();
+      const restored = loadGameState();
+      if (!restored) {
+        modal.classList.remove('hidden');
+        initGame();
+      }
+      saveGameState();
     }, 2000);
   }
 }
-startupAnimations();
+
 
 function showEndModal(win) {
   endTitle.textContent = win ? 'You won!' : 'You lost!';
@@ -329,9 +332,11 @@ function showEndModal(win) {
       span.classList.add('char-example');
 
       if (input.classList.contains('char--green')) {
-        span.classList.add('green');
+        span.classList.add('char--green');
       } else if (input.classList.contains('char--yellow')) {
-        span.classList.add('yellow');
+        span.classList.add('char--yellow');
+      } else if (input.classList.contains('char--none')) {
+        span.classList.add('char--none');
       }
 
       endWord.appendChild(span);
@@ -372,6 +377,7 @@ function keydown(e) {
   key = isPermitted(e);
   nextChar();
   gameKeydown(e);
+  saveGameState();
 }
 
 //- disabling keys
@@ -542,11 +548,15 @@ function click(e) {
   document.dispatchEvent(keyKB === 'Backspace' ? backspaceEvent : keydownEvent);
 
   // - remove modal window
-  e.target === closeModalButton && modal.classList.add('hidden');
+  if (e.target === closeModalButton) {
+    modal.classList.add('hidden');
+    saveGameState();
+  }
   if (e.target === closeEndModalButton) {
     endModal.classList.add('hidden');
     addLogoScreen();
     startupAnimations();
+    saveGameState();
   }
 }
 //
@@ -567,3 +577,82 @@ window.addEventListener('resize', documentHeight);
 documentHeight();
 
 //: ==========================================================================
+
+function saveGameState() {
+  const rowsData = rowsAllArr.map(r =>
+    Array.from(r.children).map(c => ({
+      value: c.value,
+      classes: Array.from(c.classList).filter(cls => cls.startsWith('char--')),
+    }))
+  );
+
+  const keyboard = {};
+  document.querySelectorAll('.key').forEach(k => {
+    keyboard[k.textContent] = Array.from(k.classList).filter(cls =>
+      cls.startsWith('char--')
+    );
+  });
+
+  const state = {
+    wordle,
+    currentRow,
+    count,
+    rowsData,
+    keyboard,
+    modalHidden: modal.classList.contains('hidden'),
+    endModalHidden: endModal.classList.contains('hidden'),
+  };
+
+  localStorage.setItem('wordleState', JSON.stringify(state));
+}
+
+function loadGameState() {
+  const raw = localStorage.getItem('wordleState');
+  if (!raw) return false;
+
+  try {
+    const state = JSON.parse(raw);
+    if (!state.wordle) return false;
+
+    wordle = state.wordle;
+    wordleArr = wordle.split('');
+    currentRow = state.currentRow;
+    count = state.count;
+
+    state.rowsData.forEach((rowData, rIdx) => {
+      const rowEl = rowsAllArr[rIdx];
+      rowData.forEach((charData, cIdx) => {
+        const charEl = rowEl.children[cIdx];
+        charEl.value = charData.value;
+        charEl.classList.remove(
+          'char--transition',
+          'char--rotate',
+          'char--green',
+          'char--yellow'
+        );
+        charData.classes.forEach(cls => charEl.classList.add(cls));
+      });
+    });
+
+    document.querySelectorAll('.key').forEach(k => {
+      k.classList.remove('char--green', 'char--yellow', 'char--none');
+      const classes = state.keyboard[k.textContent];
+      classes && classes.forEach(cls => k.classList.add(cls));
+    });
+
+    modal.classList.toggle('hidden', state.modalHidden);
+    endModal.classList.toggle('hidden', state.endModalHidden);
+
+    return true;
+  } catch (err) {
+    console.error('Failed to load game state', err);
+    return false;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  addLogoScreen();
+  startupAnimations();
+});
+
+window.addEventListener('beforeunload', saveGameState);


### PR DESCRIPTION
## Summary
- persist gameplay data in browser localStorage
- restore state on reload instead of starting a new game
- save state on keydown events, when modals close and when new game starts
- fix intro animation and rule modal examples
- shrink the rules text using a `.rules-desc` style so example words stay untouched

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_688793ae3f64833386c02031a4ae914e