### PR TITLE
Add header menu and modal triggers

### DIFF
--- a/css/tailwind-overrides.css
+++ b/css/tailwind-overrides.css
@@ -81,11 +81,11 @@
   gap: 1rem;
   align-items: center;
   justify-content: center;
-  position: absolute;
+  position: fixed;
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
-  z-index: 10;
+  z-index: 60;
   overflow: hidden;
 }
 
@@ -109,13 +109,13 @@
 }
 
 .overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: #9a93ff;
-  z-index: 5;
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgb(0 0 0 / var(--tw-bg-opacity));
+  --tw-bg-opacity: 0.9;
+  z-index: 50;
 }
 
 /* Neon styled version text */

--- a/index.html
+++ b/index.html
@@ -138,8 +138,8 @@ SHARAPA
           </div>
         </div>
 
-      <div class="modal hidden fixed inset-0 flex items-center justify-center bg-black">
-        <div class="modal-content bg-black/80 text-white rounded-lg p-8 text-[1.3rem] max-w-lg w-11/12">
+      <div class="modal hidden fixed inset-0 flex items-center justify-center bg-black/90">
+        <div class="modal-content bg-black/80 text-white rounded-lg p-8 text-[1.3rem] max-w-xl w-1/2">
           <h1>How to play</h1>
           <p class="rules-desc">Guess the WORDLE in six tries.</p>
           <p class="rules-desc">Each guess must be a valid five-letter word. Hit Enter to submit.</p>
@@ -179,8 +179,8 @@ SHARAPA
         </div>
       </div>
 
-      <div class="end-modal hidden fixed inset-0 flex items-center justify-center bg-black">
-        <div class="modal-content bg-black/80 text-white rounded-lg p-8 text-[1.3rem] text-center max-w-lg w-11/12">
+      <div class="end-modal hidden fixed inset-0 flex items-center justify-center bg-black/90">
+        <div class="modal-content bg-black/80 text-white rounded-lg p-8 text-[1.3rem] text-center max-w-xl w-1/2">
           <h1 class="end-title"></h1>
           <p>The correct word was:<br>
             <a class="end-word-link" href="" target="_blank" rel="noopener noreferrer">

--- a/js/wordleJS.js
+++ b/js/wordleJS.js
@@ -240,6 +240,7 @@ const endWordLink = document.querySelector('.end-word-link');
 const closeEndModalButton = document.querySelector('.closeEndModalButton');
 const restartButton = document.getElementById('restartButton');
 const howToPlayButton = document.getElementById('howToPlayButton');
+const gameContainer = document.querySelector('.game-container');
 
 // o | need to add X to close the modal window
 
@@ -248,9 +249,10 @@ let logoLetters;
 let overlay;
 
 function addLogoScreen() {
-  header.insertAdjacentHTML(
+  document.body.insertAdjacentHTML(
     'afterbegin',
     `
+        <div class='overlay'></div>
         <div class="logo-container">
           <div class="logo">W</div>
           <div class="logo">O</div>
@@ -259,12 +261,12 @@ function addLogoScreen() {
           <div class="logo">L</div>
           <div class="logo">E</div>
         </div>
-        <div class='overlay'></div>
 `
   );
   logoContainer = document.querySelector('.logo-container');
   logoLetters = [...document.querySelectorAll('.logo')];
   overlay = document.querySelector('.overlay');
+  gameContainer.classList.add('hidden');
 }
 
 function startupAnimations() {
@@ -302,6 +304,7 @@ function startupAnimations() {
     setTimeout(() => {
       logoContainer.remove();
       overlay.remove();
+      gameContainer.classList.remove('hidden');
       const restored = loadGameState();
       if (!restored) {
         modal.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- reposition restart button into a new menu under the SHARAPA logo
- add "How to Play" button that reopens the rules modal
- darken modal overlay and limit modal width
- give keyboard more top margin and darken `char--none` text color
- allow modal trigger via the new button
- reduce modal overlay transparency and nudge keyboard lower
- set custom max width

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_688793ae3f64833386c02031a4ae914e