### PR TITLE
Add gap between Wordle tiles

### DIFF
--- a/css/tailwind-overrides.css
+++ b/css/tailwind-overrides.css
@@ -26,6 +26,12 @@
 .row--false {
   animation: shake 250ms cubic-bezier(0.075, 0.82, 0.165, 1) 2;
 }
+
+/* Ensure tiles in each row have the same spacing as the rows themselves */
+.row {
+  display: flex;
+  gap: 0.5rem;
+}
 .button-container button:hover {
   transition: all 150ms ease-in-out;
   background-color: rgb(255, 166, 134);


### PR DESCRIPTION
## Summary
- add `.row` rule in `tailwind-overrides.css` to ensure tiles are spaced

## Testing
- `npm run build:css`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68882e70cf7483338d238f171486b496