### PR TITLE
Update version label style

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
       <div class="sharapaio font-bebas text-3xl md:text-4xl underline bg-black text-white px-4 py-2 ml-4 md:ml-16 flex items-center">
 SHARAPA
       </div>
-      <div class="version absolute top-0 right-0 m-4 text-2xl md:text-3xl text-blue-50">BETA 0.8.1</div>
+      <div class="version absolute top-0 right-0 m-4 text-[0.75rem] md:text-[0.9375rem] text-blue-50" style="font-family: 'neon_tubes_2regular';">ALPHA 0.8.1</div>
     </header>
     <main>
 


### PR DESCRIPTION
## Summary
- restore neon tube font styling on the version label
- shrink the label text by 50%
- mark the version as `ALPHA`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a4a02651483338f2551739991f6c8