### PR TITLE
Align border colors with tile colors

### DIFF
--- a/css/tailwind-overrides.css
+++ b/css/tailwind-overrides.css
@@ -2,14 +2,17 @@
 .char--none {
   background-color: #6a6a6a !important; /* light grey */
   color: #ffffff !important;
+  border-color: #6a6a6a !important;
 }
 .char--green {
   background-color: #8dff94 !important;
   color: #444444 !important;
+  border-color: #8dff94 !important;
 }
 .char--yellow {
   background-color: #f4ff61 !important;
   color: #444444 !important;
+  border-color: #f4ff61 !important;
 }
 .key--green {
   background-color: #8dff94 !important;

--- a/index.html
+++ b/index.html
@@ -169,7 +169,9 @@ SHARAPA
           <hr>
           <p>A new WORDLE will be available each time you start a new game!</p>
           <div class="button-container flex justify-center mt-8">
-            <button class="closeModalButton bg-[coral] text-black px-4 py-2 rounded font-bold text-3xl">PLAY</button>
+            <button class="closeModalButton bg-[coral] text-black px-4 py-2 rounded font-bold text-3xl border-2 border-black">
+              PLAY
+            </button>
           </div>
 
         </div>
@@ -184,7 +186,9 @@ SHARAPA
             </a>
           </p>
           <div class="button-container flex justify-center mt-8">
-            <button class="closeEndModalButton bg-[coral] text-black px-4 py-2 rounded font-bold text-3xl">OK</button>
+            <button class="closeEndModalButton bg-[coral] text-black px-4 py-2 rounded font-bold text-3xl border-2 border-black">
+              OK
+            </button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- ensure dynamic Wordle states also update the border color
- style modal buttons like the on-screen keyboard
- revert the border color changes on keyboard keys

## Testing
- `npm test`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_688a4ee687b083339acf34ad877bc770