### PR TITLE
Fix rules modal double appearance

### DIFF
--- a/js/wordleJS.js
+++ b/js/wordleJS.js
@@ -297,7 +297,9 @@ function startupAnimations() {
   }
 
   logoContainer.addEventListener('animationend', removeLogoScreen);
-  function removeLogoScreen() {
+  function removeLogoScreen(e) {
+    if (e.target !== logoContainer || e.animationName !== 'move-out') return;
+
     setTimeout(() => {
       logoContainer.remove();
       overlay.remove();


### PR DESCRIPTION
## Summary
- ensure startup animation only hides logo once

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a9c9284448333a2accad2c2aa84f8