### PR TITLE
Fix rules modal showing twice

### DIFF
--- a/js/wordleJS.js
+++ b/js/wordleJS.js
@@ -297,7 +297,10 @@ function startupAnimations() {
   }
 
   logoContainer.addEventListener('animationend', removeLogoScreen);
-  function removeLogoScreen() {
+  function removeLogoScreen(e) {
+    // Only act after the final animation (move-out) completes
+    if (e.animationName !== 'move-out') return;
+
     setTimeout(() => {
       logoContainer.remove();
       overlay.remove();


### PR DESCRIPTION
## Summary
- ensure rules modal only opens once after intro animation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a9c9284448333a2accad2c2aa84f8