### PR TITLE
Fix Supabase env var handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,6 @@ npm run dev
 
 Create a `.env.local` file with your Supabase credentials (see `.env.example`).
 
+These environment variables are required; the application will throw an error at startup if `NEXT_PUBLIC_SUPABASE_URL` or `NEXT_PUBLIC_SUPABASE_ANON_KEY` is missing.
+
 Users must sign in before playing. Scores are stored in Supabase and the `/leaderboard` page lists the top results, refreshed every 30 seconds.

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,8 +1,14 @@
 import { createClient as createSupabaseClient } from '@supabase/supabase-js';
 
 export function createClient() {
-  return createSupabaseClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  );
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !anonKey) {
+    throw new Error(
+      'Missing Supabase environment variables. Set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY.'
+    );
+  }
+
+  return createSupabaseClient(url, anonKey);
 }

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   reactStrictMode: true,
   env: {
-    NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL || 'http://example.com',
-    NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'anon-key',
+    NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
   },
 }


### PR DESCRIPTION
## Summary
- read Supabase env vars directly in `next.config.js`
- validate env vars before making the Supabase client
- document that environment variables are mandatory

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d273d4128833385f38f1499e779e4