### PR TITLE
feat: animate rules modal and disable input during splash

### DIFF
--- a/css/keyframes.css
+++ b/css/keyframes.css
@@ -290,3 +290,25 @@
     left: 150%;
   }
 }
+
+@keyframes modal-in {
+  from {
+    transform: scale(0.8);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@-webkit-keyframes modal-in {
+  from {
+    transform: scale(0.8);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}

--- a/css/tailwind-overrides.css
+++ b/css/tailwind-overrides.css
@@ -40,9 +40,15 @@
 .row--false {
   animation: shake 250ms cubic-bezier(0.075, 0.82, 0.165, 1) 2;
 }
-.button-container button:hover {
+
+.button-container button {
   transition: all 150ms ease-in-out;
+  box-shadow: 0 0 8px rgba(255, 166, 134, 0.6);
+}
+
+.button-container button:hover {
   background-color: rgb(255, 166, 134);
+  box-shadow: 0 0 12px rgba(255, 166, 134, 0.9);
 }
 
 /* Remove underline from the end-of-game wiki link */
@@ -59,14 +65,17 @@
   transform: translate(-50%, -50%);
   display: flex;
   gap: 0.25rem;
-  background-color: --var()
+  background-color: #7c76cc;
+  z-index: 20;
+  pointer-events: none;
 }
 
 /* Overlay covers the entire screen during the startup animation */
 .overlay {
   position: fixed;
   inset: 0;
-  background-color: rgb(--purple);
+  background-color: #7c76cc;
+  z-index: 10;
 }
 
 /* Styling for startup logo letters */
@@ -81,4 +90,9 @@
   background-color: #444444;
   border: 2px solid #000000;
   border-radius: 0.25rem;
+}
+
+/* Animation class for modal appearance */
+.modal-pop {
+  animation: modal-in 200ms ease-out forwards;
 }

--- a/js/wordleJS.js
+++ b/js/wordleJS.js
@@ -230,6 +230,7 @@ let currentRow = 0;
 //* Animation on game load
 const header = document.querySelector('.header');
 const modal = document.querySelector('.modal');
+const modalContent = document.querySelector('.modal-content');
 
 const closeModalButton = document.querySelector('.closeModalButton');
 const endModal = document.querySelector('.end-modal');
@@ -243,6 +244,7 @@ const closeEndModalButton = document.querySelector('.closeEndModalButton');
 let logoContainer;
 let logoLetters;
 let overlay;
+let allowInput = false;
 
 function addLogoScreen() {
   header.insertAdjacentHTML(
@@ -262,6 +264,7 @@ function addLogoScreen() {
   logoContainer = document.querySelector('.logo-container');
   logoLetters = [...document.querySelectorAll('.logo')];
   overlay = document.querySelector('.overlay');
+  allowInput = false;
 }
 
 addLogoScreen();
@@ -302,11 +305,16 @@ function startupAnimations() {
       logoContainer.remove();
       overlay.remove();
       modal.classList.remove('hidden');
+      modalContent.classList.add('modal-pop');
       initGame();
     }, 2000);
   }
 }
 startupAnimations();
+
+modalContent.addEventListener('animationend', () => {
+  modalContent.classList.remove('modal-pop');
+});
 
 function showEndModal(win) {
   endTitle.textContent = win ? 'You won!' : 'You lost!';
@@ -341,6 +349,7 @@ function showEndModal(win) {
   }
 
   endModal.classList.remove('hidden');
+  allowInput = false;
 }
 
 //> -----------------------------------------------------------------
@@ -368,6 +377,7 @@ document.addEventListener('keydown', keydown);
 
 //* Keydown Callback
 function keydown(e) {
+  if (!allowInput) return;
   disableKey(e);
   key = isPermitted(e);
   nextChar();
@@ -544,7 +554,10 @@ function click(e) {
   }
 
   // - remove modal window
-  if (e.target === closeModalButton) modal.classList.add('hidden');
+  if (e.target === closeModalButton) {
+    modal.classList.add('hidden');
+    allowInput = true;
+  }
   if (e.target === closeEndModalButton) {
     endModal.classList.add('hidden');
     addLogoScreen();

--- a/js/wordleJS.js
+++ b/js/wordleJS.js
@@ -299,8 +299,8 @@ function startupAnimations() {
     runAnimation();
   }
 
-  logoContainer.addEventListener('animationend', removeLogoScreen);
-  function removeLogoScreen() {
+  logoContainer.addEventListener('animationend', e => {
+    if (e.target !== logoContainer || e.animationName !== 'move-out') return;
     setTimeout(() => {
       logoContainer.remove();
       overlay.remove();
@@ -308,7 +308,7 @@ function startupAnimations() {
       modalContent.classList.add('modal-pop');
       initGame();
     }, 2000);
-  }
+  });
 }
 startupAnimations();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bootleg-wordle",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bootleg-wordle",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "ISC",
       "devDependencies": {
         "jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bootleg-wordle",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- show splash logo over solid purple overlay that blocks keystrokes
- animate rules modal entrance and add neon glow to modal buttons
- gate keyboard input until the rules modal is dismissed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e17015be0833395714c825ef02f15