### PR TITLE
Animate backspace deletion

### DIFF
--- a/css/keyframes.css
+++ b/css/keyframes.css
@@ -17,6 +17,18 @@
   }
 }
 
+@keyframes ease-out {
+  from {
+    transform: scale(100%);
+  }
+  50% {
+    transform: scale(90%);
+  }
+  to {
+    transform: scale(100%);
+  }
+}
+
 @keyframes shake {
   from {
     transform: translateX(0);

--- a/css/tailwind-overrides.css
+++ b/css/tailwind-overrides.css
@@ -17,6 +17,12 @@
   animation-duration: 100ms;
   animation-timing-function: ease-in-out;
 }
+.char--delete {
+  /* Simple shrink animation when characters are deleted */
+  animation-name: ease-out;
+  animation-duration: 100ms;
+  animation-timing-function: ease-in-out;
+}
 .char--rotate {
   /* Flip animation used when revealing results */
   animation: rotate 400ms ease-out 1;

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
       <div class="sharapaio font-bebas text-3xl md:text-4xl underline bg-black text-white px-4 py-2 ml-4 md:ml-16 flex items-center">
 SHARAPA
       </div>
-      <div class="version absolute top-0 right-0 m-4 text-[0.75rem] md:text-[0.9375rem] text-blue-50" style="font-family: 'neon_tubes_2regular';">ALPHA 0.8.3</div>
+      <div class="version absolute top-0 right-0 m-4 text-[0.75rem] md:text-[0.9375rem] text-blue-50" style="font-family: 'neon_tubes_2regular';">ALPHA 0.8.4</div>
     </header>
     <main>
 

--- a/js/wordleJS.js
+++ b/js/wordleJS.js
@@ -437,6 +437,10 @@ function gameKeydown(e) {
       //- animation on field change
       if (c.value !== '') c.classList.add('char--transition');
       if (c.value === '') c.classList.remove('char--transition');
+      if (e.key === 'Backspace') {
+        c.classList.add('char--delete');
+        setTimeout(() => c.classList.remove('char--delete'), 100);
+      }
 
       //> ---------------------------------------------------------
       //- next row + game logic (on enter)


### PR DESCRIPTION
## Summary
- add `ease-out` keyframe and `.char--delete` CSS class for shrink animation on backspace
- trigger shrink animation when deleting characters
- bump HTML version display to 0.8.4

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e722a64d48333aafd77caa4b5ffdb