### PR TITLE
Adjust mobile spacing for game and keyboard

### DIFF
--- a/css/tailwind-overrides.css
+++ b/css/tailwind-overrides.css
@@ -102,3 +102,14 @@
 .modal-pop {
   animation: modal-in 200ms ease-out forwards;
 }
+
+/* Slightly reposition the game elements on small screens */
+@media (max-width: 767px) {
+  .game-container {
+    margin-top: 1cm;
+  }
+
+  .keyboard {
+    margin-top: calc(1cm + 4rem);
+  }
+}


### PR DESCRIPTION
## Summary
- shift game container downward on mobile for better spacing
- push on-screen keyboard roughly 1cm further down on small screens

## Testing
- `npm test`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_688e76d5321c83339c9a2531ef530679