### PR TITLE
Adjust mobile spacing and bump version

### DIFF
--- a/css/tailwind-overrides.css
+++ b/css/tailwind-overrides.css
@@ -102,3 +102,20 @@
 .modal-pop {
   animation: modal-in 200ms ease-out forwards;
 }
+
+/* Slightly reposition the game elements on small screens */
+@media (max-width: 767px) {
+  .game-container {
+    margin-top: 1cm;
+  }
+
+  .keyboard {
+    margin-top: calc(1cm + 4rem);
+  }
+
+  .logo {
+    width: 3.8rem;
+    height: 3.8rem;
+    font-size: 2.85rem;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
       <div class="sharapaio font-bebas text-3xl md:text-4xl underline bg-black text-white px-4 py-2 ml-4 md:ml-16 flex items-center">
 SHARAPA
       </div>
-      <div class="version absolute top-0 right-0 m-4 text-[0.75rem] md:text-[0.9375rem] text-blue-50" style="font-family: 'neon_tubes_2regular';">ALPHA 0.8.4</div>
+      <div class="version absolute top-0 right-0 m-4 text-[0.75rem] md:text-[0.9375rem] text-blue-50" style="font-family: 'neon_tubes_2regular';">ALPHA 0.8.5</div>
     </header>
     <main>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bootleg-wordle",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bootleg-wordle",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "license": "ISC",
       "devDependencies": {
         "jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bootleg-wordle",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- shift game container downward on mobile for better spacing
- push on-screen keyboard roughly 1cm further down on small screens
- shrink startup logo 5% on mobile
- bump version to 0.8.5 in package files and HTML header

## Testing
- `npm test`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_688e76d5321c83339c9a2531ef530679