### PR TITLE
Restore Wordle animations and fix word loading

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import '../css/tailwind.css'
 import '../css/tailwind-overrides.css'
+import '../css/keyframes.css'
 import type { ReactNode } from 'react'
 import SupabaseProvider from '@/components/SupabaseProvider'
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ export default function HomePage() {
   return (
     <div>
       <main dangerouslySetInnerHTML={{ __html: markup }} />
+      <Script src="/js/wordle-words-list.js" strategy="beforeInteractive" />
       <Script src="/js/wordleJS.js" strategy="afterInteractive" />
       <LoginModal />
     </div>


### PR DESCRIPTION
## Summary
- import missing keyframe styles so logo and tile animations run again
- load the word list before the game script to restore keyboard input and modal behaviour

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e84a8c920833389a97c302add1201