### PR TITLE
Restore Wordle animations and keyboard input

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import '../css/tailwind.css'
 import '../css/tailwind-overrides.css'
+import '../css/keyframes.css'
 import type { ReactNode } from 'react'
 import SupabaseProvider from '@/components/SupabaseProvider'
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ export default function HomePage() {
   return (
     <div>
       <main dangerouslySetInnerHTML={{ __html: markup }} />
+      <Script src="/js/wordle-words-list.js" strategy="beforeInteractive" />
       <Script src="/js/wordleJS.js" strategy="afterInteractive" />
       <LoginModal />
     </div>

--- a/public/js/wordleJS.js
+++ b/public/js/wordleJS.js
@@ -513,9 +513,9 @@ function gameKeydown(e) {
     });
 
     //- sets a 'guess' word form characters
-    guess = Array.from([...r.children]).reduce((acc, cur, i, arr) => {
+    guess = Array.from(r.children).reduce((acc, cur) => {
       return acc + cur.value.toLowerCase();
-    }, Array.from([...r.children][0]));
+    }, '');
 
     guessArr = guess?.split('');
   });


### PR DESCRIPTION
## Summary
- load word list and game scripts in order so key presses populate the board and the rules modal reappears
- include keyframe definitions to reinstate logo, input, and reveal animations
- fix guess assembly bug in `wordleJS.js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e84a8c920833389a97c302add1201